### PR TITLE
Fix port number in quickstart guide

### DIFF
--- a/docs/docs/quickstart.html
+++ b/docs/docs/quickstart.html
@@ -31,7 +31,7 @@ plugin but to get folks started quickly Lustre comes with a simple preview serve
 built-in. </p><p>First run `gleam build` to ensure your app is compiled. Then, depending on your
 preferred platform, run `gleam run -m lustre/try --target erlang` or
 `gleam run -m lustre/try --target javascript` to start the preview server and
-head over to `localhost:8080`. If all goes well, you should see &quot;Hello, world!&quot;
+head over to `localhost:1234`. If all goes well, you should see &quot;Hello, world!&quot;
 on the page!</p></section><section class="lustre-ui-stack"><div id="adding-interactivity" class="lustre-ui-aside align-centre"><h3>Adding interactivity</h3><div aria-hidden="true" class="lustre-ui-cluster"></div></div><p>Now that we know how to get things up and running, let&#39;s try something a little
 more exciting and add some interactivity. Replace the contents of your 
 `lustre_quickstart.gleam` file with the following:</p><pre class="lustre-ui-box"><code data-lang="gleam" class="language-gleam">import gleam/int


### PR DESCRIPTION
The quickstart guide says to go to localhost:8080 when launching through `lustre/try`, but `lustre/try` listens on port 1234 by default.